### PR TITLE
Add dl-4 apk repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.7-alpine
 
+RUN echo 'http://dl-4.alpinelinux.org/alpine/v3.15/main' >> /etc/apk/repositories
+
 RUN set -x -e; \
     apk add --update --no-cache bash make g++; \
     gem install package_cloud


### PR DESCRIPTION
Builds are failing because apk repos are down:
```
  + apk add --update --no-cache bash make g++
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
  WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/main: temporary error (try again later)
  WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/community: temporary error (try again later)
  ERROR: unable to select packages:
    bash (no such package):
      required by: world[bash]
    g++ (no such package):
      required by: world[g++]
    make (no such package):
      required by: world[make]
```

This PR adds another repo, `dl-4`, from which packages can be installed.